### PR TITLE
LPA-3215 implement content for sign in page time out

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,24 @@
+REFUND_REPOS = opg-refunds-maintenance
+REFUND_HELPER_REPOS = opg-refunds-caseworker-datamodels
+REFUND_PRIVATE_REPOS = lpa-refund-local-dev
+
+.PHONY: local
+
+local:
+	@for REPO in $(REFUND_PRIVATE_REPOS); do \
+		if [ ! -d "../$$REPO" ]; then \
+			git clone --branch master git@gitlab.service.opg.digital:lpa-refunds/$$REPO.git ../$$REPO; \
+		fi \
+	done
+
+	@for REPO in $(REFUND_REPOS); do \
+		if [ ! -d "../$$REPO" ]; then \
+			git clone --branch master git@github.com:ministryofjustice/$$REPO.git ../$$REPO; \
+		fi \
+	done
+
+	@for REPO in $(REFUND_HELPER_REPOS); do \
+		if [ ! -d "../$$REPO" ]; then \
+			git clone --branch master git@github.com:ministryofjustice/$$REPO.git ../$$REPO; \
+		fi \
+	done

--- a/caseworker-front/src/App/templates/app/sign-in-page.phtml
+++ b/caseworker-front/src/App/templates/app/sign-in-page.phtml
@@ -25,6 +25,12 @@ $this->addErrorMap([
             'field'     => 'Please enter a password',
         ],
     ],
+    'secret' => [
+        'csrf' => [
+            'summary'   => 'As you have not used this service for over 60 minutes, the page has timed out. We\'ve now refreshed the page - please try to sign in again.',
+            'field'     => ''
+        ]
+    ],
 ]);
 ?>
 


### PR DESCRIPTION
Add a proper error message for issues caused by CSRF failures.

Also add a new-starter makefile that pulls the externally needed repos this needs to work. Removed everything else from the makefile. This makes the readme correct.