### PR TITLE
Pin Images to current latest version 0.0.318

### DIFF
--- a/caseworker-api/Dockerfile
+++ b/caseworker-api/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.service.opg.digital/opg-php-fpm-71-ppa-1604
+FROM registry.service.opg.digital/opg-php-fpm-71-ppa-1604:0.0.318
 
 RUN apt update && apt install -y \
     php7.1-zip php7.1-gd php7.1-bcmath

--- a/caseworker-front/Dockerfile
+++ b/caseworker-front/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.service.opg.digital/opg-php-fpm-71-ppa-1604
+FROM registry.service.opg.digital/opg-php-fpm-71-ppa-1604:0.0.318
 
 RUN apt update && apt install -y \
     php7.1-bcmath

--- a/docker-compose.windows.yml
+++ b/docker-compose.windows.yml
@@ -2,7 +2,7 @@ version: '2'
 
 services:
   router:
-    image: registry.service.opg.digital/opg-nginx-router-1604
+    image: registry.service.opg.digital/opg-nginx-router-1604:0.0.318
     ports:
       - 80:80
       - 443:443

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '2'
 
 services:
   router:
-    image: registry.service.opg.digital/opg-nginx-router-1604
+    image: registry.service.opg.digital/opg-nginx-router-1604:0.0.318
     links:
       - front
       - caseworker

--- a/local-sns/Dockerfile
+++ b/local-sns/Dockerfile
@@ -1,4 +1,4 @@
-from registry.service.opg.digital/opg-golang-alpine:0.0.318
+from registry.service.opg.digital/opg-golang-alpine
 
 ARG LIB_VERSION="0.0.3"
 ARG LIB_PATH="$GOPATH/src/github.com/NSmithUK/local-sns-go"

--- a/local-sns/Dockerfile
+++ b/local-sns/Dockerfile
@@ -1,4 +1,4 @@
-from registry.service.opg.digital/opg-golang-alpine
+from registry.service.opg.digital/opg-golang-alpine:0.0.318
 
 ARG LIB_VERSION="0.0.3"
 ARG LIB_PATH="$GOPATH/src/github.com/NSmithUK/local-sns-go"

--- a/public-front/Dockerfile
+++ b/public-front/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.service.opg.digital/opg-php-fpm-71-ppa-1604
+FROM registry.service.opg.digital/opg-php-fpm-71-ppa-1604:0.0.318
 
 RUN apt update && apt install -y \
     php7.1-bcmath


### PR DESCRIPTION
Starfox needs to update the base images for the Sirius ECS migration. I've pinned all the refunds version to the latest version in master before our upgrade.