### PR TITLE
Create and use missing service role for ecs autoscaling

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,17 @@
-- repo: git://github.com/antonbabenko/pre-commit-terraform
-  rev: v1.19.0
-  hooks:
-    - id: terraform_fmt
-    - id: terraform_validate
+# See https://pre-commit.com for more information
+# See https://pre-commit.com/hooks.html for more hooks
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v2.0.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+  - repo: https://github.com/antonbabenko/pre-commit-terraform
+    rev: v1.19.0
+    hooks:
+      - id: terraform_fmt
+      - id: terraform_validate
+  - repo: https://github.com/awslabs/git-secrets
+    rev: master
+    hooks:
+      - id: git-secrets

--- a/docs/runbooks/pre_commit.md
+++ b/docs/runbooks/pre_commit.md
@@ -1,0 +1,7 @@
+# Pre-Commit Hooks
+
+The root of this project contains a `.pre-commit-config.yaml` file used with [pre-commit](https://pre-commit.com/) to automate the running of tasks when a commit is made with github.
+
+## pre-commit-terraform
+
+Go to [pre-commit-terraform](https://github.com/antonbabenko/pre-commit-terraform) for instructions on installing pre-commit, pre-commit-terraform dependencies and available terraform hooks.

--- a/terraform/account/autoscaling_role.tf
+++ b/terraform/account/autoscaling_role.tf
@@ -1,0 +1,3 @@
+resource "aws_iam_service_linked_role" "ecs_autoscaling_service_role" {
+  aws_service_name = "ecs.application-autoscaling.amazonaws.com"
+}

--- a/terraform/environment/autoscaling_role.tf
+++ b/terraform/environment/autoscaling_role.tf
@@ -1,3 +1,0 @@
-data "aws_iam_role" "ecs_autoscaling_service_role" {
-  name = "AWSServiceRoleForApplicationAutoScaling_ECSService"
-}

--- a/terraform/environment/vpc_data_sources.tf
+++ b/terraform/environment/vpc_data_sources.tf
@@ -59,3 +59,7 @@ data "aws_kms_alias" "bank_encrypt_decrypt" {
 data "aws_iam_policy" "restrict_to_vpc_endpoints" {
   arn = "arn:aws:iam::${local.account.account_id}:policy/restrict-to-vpc-endpoints"
 }
+
+data "aws_iam_role" "ecs_autoscaling_service_role" {
+  name = "AWSServiceRoleForApplicationAutoScaling_ECSService"
+}


### PR DESCRIPTION
## Purpose
Previous PR, https://github.com/ministryofjustice/opg-refunds/pull/115 sets up autoscaling for ecs. This relies on a service role AWSServiceRoleForApplicationAutoScaling_ECSService, but that role has not been created in preproduction and production accounts.
This PR creates that service role.

Fixes LPA-3440

## Approach

The service role is created in the terraform/account configuration, and then used in the terraform/environment configuration as a data source.

## Learning

There appear to be some scenarios where AWS will automatically create and use service roles as part creating other resources in the AWS console.

## Checklist

* [x] I have performed a self-review of my own code
* [x] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [x] I have added tests to prove my work
* [ ] The product team have tested these changes
