### PR TITLE
Refunds 3566 set env variable to 30

### DIFF
--- a/caseworker-api/config/autoload/envs.global.php
+++ b/caseworker-api/config/autoload/envs.global.php
@@ -79,7 +79,7 @@ return [
             'completer_id' => getenv('OPG_REFUNDS_SSCL_COMPLETER_ID') ?: '',
             'approver_id' => getenv('OPG_REFUNDS_SSCL_APPROVER_ID') ?: '',
         ],
-        'delete_after_historical_refund_dates' => getenv('OPG_REFUNDS_DELETE_AFTER_HISTORICAL_REFUND_DATES') ?: 1
+        'delete_after_historical_refund_dates' => getenv('OPG_REFUNDS_DELETE_AFTER_HISTORICAL_REFUND_DATES') ?: 30
     ],
 
     'notify' => [

--- a/caseworker-api/src/App/src/Service/Spreadsheet.php
+++ b/caseworker-api/src/App/src/Service/Spreadsheet.php
@@ -215,6 +215,7 @@ class Spreadsheet implements Initializer\LogSupportInterface
 
         $this->getLogger()->debug('Historic refund dates retrieved in ' . $this->getElapsedTimeInMs($start) . 'ms');
 
+        //returns an array of historic refund dates
         return $historicRefundDates;
     }
 
@@ -448,13 +449,20 @@ class Spreadsheet implements Initializer\LogSupportInterface
 
     private function clearBankDetails()
     {
+        //Gets an array of historic refund dates
         $historicRefundDates = $this->getAllHistoricRefundDates();
 
+        $this->getLogger()->debug('1. Historic Refund Dates are :' . $this->$historicRefundDates);
+
+
         $deleteAfterHistoricalRefundDates = $this->spreadsheetConfig['delete_after_historical_refund_dates'];
+        $this->getLogger()->debug('2. The deleteAfterHistoricalRefundDates variable is :' . $this->$deleteAfterHistoricalRefundDates);
+
         if (count($historicRefundDates) >= $deleteAfterHistoricalRefundDates) {
             $start = microtime(true);
 
             $deleteAfterHistoricalRefundDate = new DateTime($historicRefundDates[$deleteAfterHistoricalRefundDates - 1]);
+            $this->getLogger()->debug('3. The deleteAfterHistoricalRefundDate variable is :' . $this->$deleteAfterHistoricalRefundDate);
 
             $statement = $this->entityManager->getConnection()->executeQuery(
                 'UPDATE claim SET json_data = json_data #- \'{account,details}\' WHERE id IN (SELECT c.id FROM claim c LEFT OUTER JOIN payment p ON c.id = p.claim_id WHERE (c.json_data->\'account\'->\'details\') IS NOT NULL AND ((status = \'rejected\' AND finished_datetime < :date) OR p.added_datetime < :date))',


### PR DESCRIPTION
## Purpose
_Briefly describe the purpose of the change, and/or link to the JIRA ticket for context_

Fixes LPA-3566

## Approach

Set the 'delete_after_historical_refund_dates' to 30 by default.
This means 30 days after a refund sop form is submitted the record is made eligible to be deleted.

## Learning

_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about the Refunds service_

## Checklist

* [x] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] The product team have tested these changes
