### PR TITLE
changes to set the GA tracking id for production account alone

### DIFF
--- a/public-front/config/autoload/envs.global.php
+++ b/public-front/config/autoload/envs.global.php
@@ -17,7 +17,7 @@ return [
     'analytics' => [
         'google' => [
             'id' => getenv('OPG_REFUNDS_PUBLIC_FRONT_GOOGLE_ANALYTICS_TRACKING_ID') ?: null,
-            'govId' => getenv('OPG_REFUNDS_PUBLIC_FRONT_GOOGLE_ANALYTICS_TRACKING_GOVID') ?: null,
+            'govId' => getenv('OPG_REFUNDS_PUBLIC_FRONT_GOOGLE_ANALYTICS_TRACKING_GOV_ID') ?: null,
         ],
     ],
 
@@ -55,7 +55,7 @@ return [
         ],
 
     ],
-    
+
     'security' => [
 
         'kms' => [

--- a/terraform/environment/ecs_public_front.tf
+++ b/terraform/environment/ecs_public_front.tf
@@ -225,8 +225,8 @@ locals {
       { "name" : "OPG_REFUNDS_DB_APPLICATIONS_NAME", "value": "applications" },
       { "name" : "OPG_REFUNDS_DB_APPLICATIONS_WRITE_USERNAME", "value": "applications" },
       { "name" : "OPG_REFUNDS_PUBLIC_FRONT_KMS_ENCRYPT_KEY_ALIAS", "value": "${data.aws_kms_alias.bank_encrypt_decrypt.name}" },
-      { "name" : "OPG_REFUNDS_PUBLIC_FRONT_GOOGLE_ANALYTICS_TRACKING_ID", "value": "UA-105655306-1" },
-      { "name" : "OPG_REFUNDS_PUBLIC_FRONT_GOOGLE_ANALYTICS_TRACKING_GOVID", "value": "UA-145652997-1" },
+      { "name" : "OPG_REFUNDS_PUBLIC_FRONT_GOOGLE_ANALYTICS_TRACKING_ID", "value": "${local.account.opg_refunds_google_analytics_tracking_id}" },
+      { "name" : "OPG_REFUNDS_PUBLIC_FRONT_GOOGLE_ANALYTICS_TRACKING_GOV_ID", "value": "${local.account.opg_refunds_google_analytics_tracking_gov_id}" },
       { "name" : "OPG_REFUNDS_STACK_TYPE", "value": "${local.account.opg_refunds_stack_type}" }
     ]
   }

--- a/terraform/environment/locals.tf
+++ b/terraform/environment/locals.tf
@@ -22,6 +22,8 @@ variable "accounts" {
       public_front_autoscaling_metric_track_memory = number
       opg_refunds_stack_type                       = string
       days_to_wait_before_expiry                   = number
+      opg_refunds_google_analytics_tracking_id     = string
+      opg_refunds_google_analytics_tracking_gov_id = string
 
     })
   )

--- a/terraform/environment/terraform.tfvars.json
+++ b/terraform/environment/terraform.tfvars.json
@@ -16,7 +16,9 @@
       "public_front_autoscaling_metric_track_cpu": 80,
       "public_front_autoscaling_metric_track_memory": 80,
       "opg_refunds_stack_type": "testing",
-      "days_to_wait_before_expiry": 1
+      "days_to_wait_before_expiry": 1,
+      "opg_refunds_google_analytics_tracking_id": "",
+      "opg_refunds_google_analytics_tracking_gov_id": ""
     },
     "preproduction": {
       "account_id": "764856231715",
@@ -29,7 +31,9 @@
       "public_front_autoscaling_metric_track_cpu": 80,
       "public_front_autoscaling_metric_track_memory": 80,
       "opg_refunds_stack_type": "testing",
-      "days_to_wait_before_expiry": 1
+      "days_to_wait_before_expiry": 1,
+      "opg_refunds_google_analytics_tracking_id": "",
+      "opg_refunds_google_analytics_tracking_gov_id": ""
     },
     "production": {
       "account_id": "805626386523",
@@ -42,7 +46,9 @@
       "public_front_autoscaling_metric_track_cpu": 80,
       "public_front_autoscaling_metric_track_memory": 80,
       "opg_refunds_stack_type": "production",
-      "days_to_wait_before_expiry": 30
+      "days_to_wait_before_expiry": 30,
+      "opg_refunds_google_analytics_tracking_id": "UA-105655306-1",
+      "opg_refunds_google_analytics_tracking_gov_id": "UA-145652997-1"
     }
   }
 }


### PR DESCRIPTION
## Purpose
The ticket is add the env variable for the google analytics tracking id for production only.

Fixes LPA-3559

## Approach
Added the environment variables for the GA tracking id for the different accounts

## Learning

_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about the Refunds service_

## Checklist

* [x] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] The product team have tested these changes
