### PR TITLE
add lb sg rule to permit ingress for it health check

### DIFF
--- a/terraform/environment/load_balancer_caseworker_front.tf
+++ b/terraform/environment/load_balancer_caseworker_front.tf
@@ -70,7 +70,7 @@ resource "aws_security_group_rule" "caseworker_front_loadbalancer_ingress" {
 }
 
 resource "aws_security_group_rule" "caseworker_front_loadbalancer_ingress_ithc" {
-  count             = local.environment != "production" ? 1 : 0
+  count             = local.environment == "preproduction" ? 1 : 0
   type              = "ingress"
   from_port         = 443
   to_port           = 443

--- a/terraform/environment/load_balancer_caseworker_front.tf
+++ b/terraform/environment/load_balancer_caseworker_front.tf
@@ -69,6 +69,16 @@ resource "aws_security_group_rule" "caseworker_front_loadbalancer_ingress" {
   security_group_id = aws_security_group.caseworker_front_loadbalancer.id
 }
 
+resource "aws_security_group_rule" "caseworker_front_loadbalancer_ingress_ithc" {
+  count             = local.environment != "production" ? 1 : 0
+  type              = "ingress"
+  from_port         = 443
+  to_port           = 443
+  protocol          = "tcp"
+  cidr_blocks       = ["54.37.241.156/30"]
+  security_group_id = aws_security_group.caseworker_front_loadbalancer.id
+}
+
 // Allow http traffic in to be redirected to https
 resource "aws_security_group_rule" "caseworker_front_loadbalancer_ingress_http" {
   type              = "ingress"

--- a/terraform/environment/load_balancer_public_front.tf
+++ b/terraform/environment/load_balancer_public_front.tf
@@ -113,6 +113,16 @@ resource "aws_security_group_rule" "public_front_loadbalancer_ingress" {
   security_group_id = aws_security_group.public_front_loadbalancer.id
 }
 
+resource "aws_security_group_rule" "public_front_loadbalancer_ingress_ithc" {
+  count             = local.environment != "production" ? 1 : 0
+  type              = "ingress"
+  from_port         = 443
+  to_port           = 443
+  protocol          = "tcp"
+  cidr_blocks       = ["54.37.241.156/30"]
+  security_group_id = aws_security_group.public_front_loadbalancer.id
+}
+
 // Allow http traffic in to be redirected to https
 resource "aws_security_group_rule" "public_front_loadbalancer_ingress_http" {
   type              = "ingress"

--- a/terraform/environment/load_balancer_public_front.tf
+++ b/terraform/environment/load_balancer_public_front.tf
@@ -114,7 +114,7 @@ resource "aws_security_group_rule" "public_front_loadbalancer_ingress" {
 }
 
 resource "aws_security_group_rule" "public_front_loadbalancer_ingress_ithc" {
-  count             = local.environment != "production" ? 1 : 0
+  count             = local.environment == "preproduction" ? 1 : 0
   type              = "ingress"
   from_port         = 443
   to_port           = 443


### PR DESCRIPTION
## Purpose
The ITHC requires the Auditing company access to non-production services.

Fixes LPA-3597

## Approach

Create a security group rule for each load balancer allowing ingress from BSI's range.

## Checklist

* [x] I have performed a self-review of my own code
* [x] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] The product team have tested these changes
