### PR TITLE
add public-front, caseworker and shared as possible tags

### DIFF
--- a/terraform/account/certificate.tf
+++ b/terraform/account/certificate.tf
@@ -27,7 +27,7 @@ resource "aws_acm_certificate" "certificate_public_front" {
   lifecycle {
     create_before_destroy = true
   }
-  tags = local.default_tags
+  tags = merge(local.default_tags, local.public_front_component_tag)
 }
 
 //------------------------
@@ -54,7 +54,7 @@ resource "aws_acm_certificate" "certificate_caseworker_front" {
   lifecycle {
     create_before_destroy = true
   }
-  tags = local.default_tags
+  tags = merge(local.default_tags, local.caseworker_component_tag)
 }
 
 # claim-power-of-attorney-refund.service.gov.uk

--- a/terraform/account/certificate.tf
+++ b/terraform/account/certificate.tf
@@ -70,10 +70,7 @@ resource "aws_acm_certificate" "claim_power_of_attorney_refund_service_gov_uk" {
   lifecycle {
     create_before_destroy = true
   }
-  tags = merge(
-    local.default_tags,
-    map("component", "public facing dns")
-  )
+  tags = merge(local.default_tags, local.public_front_component_tag)
 }
 
 resource "aws_acm_certificate_validation" "claim_power_of_attorney_refund_service_gov_uk" {
@@ -103,10 +100,7 @@ resource "aws_acm_certificate" "caseworker_refunds_opg_digital" {
   lifecycle {
     create_before_destroy = true
   }
-  tags = merge(
-    local.default_tags,
-    map("component", "public facing dns")
-  )
+  tags = merge(local.default_tags, local.public_front_component_tag)
 }
 
 resource "aws_acm_certificate_validation" "caseworker_refunds_opg_digital" {

--- a/terraform/account/lb_access_logs.tf
+++ b/terraform/account/lb_access_logs.tf
@@ -25,7 +25,7 @@ data "aws_iam_policy_document" "loadbalancer_logging" {
 resource "aws_s3_bucket" "access_log" {
   bucket = "lpa-refunds-${terraform.workspace}-lb-access-logs"
   acl    = "private"
-  tags   = local.default_tags
+  tags   = merge(local.default_tags, local.shared_component_tag)
 
   server_side_encryption_configuration {
     rule {

--- a/terraform/account/locals.tf
+++ b/terraform/account/locals.tf
@@ -36,5 +36,17 @@ locals {
     source-code            = "https://github.com/ministryofjustice/opg-refunds"
   }
 
+  public_front_component_tag = {
+    component = "public-front"
+  }
+
+  caseworker_component_tag = {
+    component = "caseworker"
+  }
+
+  shared_component_tag = {
+    component = "shared"
+  }
+
   default_tags = merge(local.mandatory_moj_tags, local.optional_tags)
 }

--- a/terraform/account/put_secrets.tf
+++ b/terraform/account/put_secrets.tf
@@ -15,22 +15,22 @@ resource "aws_secretsmanager_secret" "opg_refunds_public_front_session_encryptio
 
 resource "aws_secretsmanager_secret" "opg_refunds_bank_hash_salt" {
   name = "${local.account_name}/opg_refunds_bank_hash_salt"
-  tags = local.default_tags
+  tags = merge(local.default_tags, local.shared_component_tag)
 }
 
 resource "aws_secretsmanager_secret" "opg_refunds_notify_api_key" {
   name = "${local.account_name}/opg_refunds_notify_api_key"
-  tags = local.default_tags
+  tags = merge(local.default_tags, local.shared_component_tag)
 }
 
 resource "aws_secretsmanager_secret" "opg_refunds_db_applications_write_username" {
   name = "${local.account_name}/opg_refunds_db_applications_write_username"
-  tags = local.default_tags
+  tags = merge(local.default_tags, local.public_front_component_tag)
 }
 
 resource "aws_secretsmanager_secret" "opg_refunds_db_applications_write_password" {
   name = "${local.account_name}/opg_refunds_db_applications_write_password"
-  tags = local.default_tags
+  tags = merge(local.default_tags, local.public_front_component_tag)
 }
 
 resource "aws_secretsmanager_secret" "opg_refunds_public_front_beta_link_signature_key" {
@@ -40,7 +40,7 @@ resource "aws_secretsmanager_secret" "opg_refunds_public_front_beta_link_signatu
 
 resource "aws_secretsmanager_secret" "opg_refunds_ad_link_signature_key" {
   name = "${local.account_name}/opg_refunds_ad_link_signature_key"
-  tags = local.default_tags
+  tags = merge(local.default_tags, local.shared_component_tag)
 }
 
 resource "aws_secretsmanager_secret" "opg_refunds_public_front_full_key_public" {
@@ -66,56 +66,56 @@ resource "aws_secretsmanager_secret" "opg_refunds_public_front_full_key_public_d
 # ingestion and db secrets
 resource "aws_secretsmanager_secret" "postgres_password" {
   name = "${local.account_name}/postgres_password"
-  tags = merge(local.default_tags, local.public_front_component_tag)
+  tags = merge(local.default_tags, local.shared_component_tag)
 }
 resource "aws_secretsmanager_secret" "opg_refunds_db_applications_full_password" {
   name = "${local.account_name}/opg_refunds_db_applications_full_password"
-  tags = local.default_tags
+  tags = merge(local.default_tags, local.public_front_component_tag)
 }
 
 resource "aws_secretsmanager_secret" "opg_refunds_db_applications_migration_password" {
   name = "${local.account_name}/opg_refunds_db_applications_migration_password"
-  tags = local.default_tags
+  tags = merge(local.default_tags, local.public_front_component_tag)
 }
 
 resource "aws_secretsmanager_secret" "opg_refunds_db_cases_full_password" {
   name = "${local.account_name}/opg_refunds_db_cases_full_password"
-  tags = local.default_tags
+  tags = merge(local.default_tags, local.caseworker_component_tag)
 }
 
 resource "aws_secretsmanager_secret" "opg_refunds_db_cases_migration_password" {
   name = "${local.account_name}/opg_refunds_db_cases_migration_password"
-  tags = local.default_tags
+  tags = merge(local.default_tags, local.caseworker_component_tag)
 }
 
 resource "aws_secretsmanager_secret" "opg_refunds_db_sirius_full_password" {
   name = "${local.account_name}/opg_refunds_db_sirius_full_password"
-  tags = local.default_tags
+  tags = merge(local.default_tags, local.caseworker_component_tag)
 }
 
 resource "aws_secretsmanager_secret" "opg_refunds_db_sirius_migration_password" {
   name = "${local.account_name}/opg_refunds_db_sirius_migration_password"
-  tags = local.default_tags
+  tags = merge(local.default_tags, local.caseworker_component_tag)
 }
 
 resource "aws_secretsmanager_secret" "opg_refunds_db_meris_full_password" {
   name = "${local.account_name}/opg_refunds_db_meris_full_password"
-  tags = local.default_tags
+  tags = merge(local.default_tags, local.caseworker_component_tag)
 }
 
 resource "aws_secretsmanager_secret" "opg_refunds_db_meris_migration_password" {
   name = "${local.account_name}/opg_refunds_db_meris_migration_password"
-  tags = local.default_tags
+  tags = merge(local.default_tags, local.caseworker_component_tag)
 }
 
 resource "aws_secretsmanager_secret" "opg_refunds_db_finance_full_password" {
   name = "${local.account_name}/opg_refunds_db_finance_full_password"
-  tags = local.default_tags
+  tags = merge(local.default_tags, local.caseworker_component_tag)
 }
 
 resource "aws_secretsmanager_secret" "opg_refunds_db_finance_migration_password" {
   name = "${local.account_name}/opg_refunds_db_finance_migration_password"
-  tags = local.default_tags
+  tags = merge(local.default_tags, local.caseworker_component_tag)
 }
 
 resource "aws_secretsmanager_secret" "opg_refunds_caseworker_admin_username" {
@@ -131,17 +131,17 @@ resource "aws_secretsmanager_secret" "opg_refunds_caseworker_admin_password" {
 # SSCL data
 resource "aws_secretsmanager_secret" "opg_refunds_sscl_entity" {
   name = "${local.account_name}/opg_refunds_sscl_entity"
-  tags = local.default_tags
+  tags = merge(local.default_tags, local.caseworker_component_tag)
 }
 resource "aws_secretsmanager_secret" "opg_refunds_sscl_cost_centre" {
   name = "${local.account_name}/opg_refunds_sscl_cost_centre"
-  tags = local.default_tags
+  tags = merge(local.default_tags, local.caseworker_component_tag)
 }
 resource "aws_secretsmanager_secret" "opg_refunds_sscl_account" {
   name = "${local.account_name}/opg_refunds_sscl_account"
-  tags = local.default_tags
+  tags = merge(local.default_tags, local.caseworker_component_tag)
 }
 resource "aws_secretsmanager_secret" "opg_refunds_sscl_analysis" {
   name = "${local.account_name}/opg_refunds_sscl_analysis"
-  tags = local.default_tags
+  tags = merge(local.default_tags, local.caseworker_component_tag)
 }

--- a/terraform/account/put_secrets.tf
+++ b/terraform/account/put_secrets.tf
@@ -5,12 +5,12 @@
 # public front secrets
 resource "aws_secretsmanager_secret" "opg_refunds_public_front_session_encryption_key" {
   name = "${local.account_name}/opg_refunds_public_front_session_encryption_key"
-  tags = local.default_tags
+  tags = merge(local.default_tags, local.public_front_component_tag)
 }
 
 resource "aws_secretsmanager_secret" "opg_refunds_public_front_session_encryption_keys" {
   name = "${local.account_name}/opg_refunds_public_front_session_encryption_keys"
-  tags = local.default_tags
+  tags = merge(local.default_tags, local.public_front_component_tag)
 }
 
 resource "aws_secretsmanager_secret" "opg_refunds_bank_hash_salt" {
@@ -35,7 +35,7 @@ resource "aws_secretsmanager_secret" "opg_refunds_db_applications_write_password
 
 resource "aws_secretsmanager_secret" "opg_refunds_public_front_beta_link_signature_key" {
   name = "${local.account_name}/opg_refunds_public_front_beta_link_signature_key"
-  tags = local.default_tags
+  tags = merge(local.default_tags, local.public_front_component_tag)
 }
 
 resource "aws_secretsmanager_secret" "opg_refunds_ad_link_signature_key" {
@@ -45,28 +45,28 @@ resource "aws_secretsmanager_secret" "opg_refunds_ad_link_signature_key" {
 
 resource "aws_secretsmanager_secret" "opg_refunds_public_front_full_key_public" {
   name = "${local.account_name}/opg_refunds_public_front_full_key_public"
-  tags = local.default_tags
+  tags = merge(local.default_tags, local.public_front_component_tag)
 }
 
 resource "aws_secretsmanager_secret" "opg_refunds_public_front_bank_key_public" {
   name = "${local.account_name}/opg_refunds_public_front_bank_key_public"
-  tags = local.default_tags
+  tags = merge(local.default_tags, local.public_front_component_tag)
 }
 
 resource "aws_secretsmanager_secret" "opg_refunds_public_front_bank_key_public_data" {
   name = "${local.account_name}/opg_refunds_public_front_bank_key_public_data"
-  tags = local.default_tags
+  tags = merge(local.default_tags, local.public_front_component_tag)
 }
 
 resource "aws_secretsmanager_secret" "opg_refunds_public_front_full_key_public_data" {
   name = "${local.account_name}/opg_refunds_public_front_full_key_public_data"
-  tags = local.default_tags
+  tags = merge(local.default_tags, local.public_front_component_tag)
 }
 
 # ingestion and db secrets
 resource "aws_secretsmanager_secret" "postgres_password" {
   name = "${local.account_name}/postgres_password"
-  tags = local.default_tags
+  tags = merge(local.default_tags, local.public_front_component_tag)
 }
 resource "aws_secretsmanager_secret" "opg_refunds_db_applications_full_password" {
   name = "${local.account_name}/opg_refunds_db_applications_full_password"
@@ -120,12 +120,12 @@ resource "aws_secretsmanager_secret" "opg_refunds_db_finance_migration_password"
 
 resource "aws_secretsmanager_secret" "opg_refunds_caseworker_admin_username" {
   name = "${local.account_name}/opg_refunds_caseworker_admin_username"
-  tags = local.default_tags
+  tags = merge(local.default_tags, local.caseworker_component_tag)
 }
 
 resource "aws_secretsmanager_secret" "opg_refunds_caseworker_admin_password" {
   name = "${local.account_name}/opg_refunds_caseworker_admin_password"
-  tags = local.default_tags
+  tags = merge(local.default_tags, local.caseworker_component_tag)
 }
 
 # SSCL data

--- a/terraform/account/vpc_endpoints.tf
+++ b/terraform/account/vpc_endpoints.tf
@@ -37,7 +37,8 @@ resource "aws_vpc_endpoint" "dynamodb" {
 
   tags = merge(
     local.default_tags,
-    map("Name", "DynamoDB Gateway")
+    map("Name", "DynamoDB Gateway"),
+    local.shared_component_tag
   )
 }
 
@@ -60,7 +61,8 @@ resource "aws_vpc_endpoint" "kms" {
 
   tags = merge(
     local.default_tags,
-    map("Name", "KMS Gateway")
+    map("Name", "KMS Gateway"),
+    local.shared_component_tag
   )
 }
 
@@ -75,5 +77,6 @@ resource "aws_security_group" "kms_vpc_endpoint" {
     cidr_blocks = aws_subnet.private.*.cidr_block
   }
 
-  tags = local.default_tags
+  tags = merge(local.default_tags, local.shared_component_tag)
+
 }

--- a/terraform/account/vpc_flowlogs.tf
+++ b/terraform/account/vpc_flowlogs.tf
@@ -7,13 +7,13 @@ resource "aws_flow_log" "vpc_flow_logs" {
 
 resource "aws_cloudwatch_log_group" "vpc_flow_logs" {
   name = "vpc_flow_logs"
-  tags = local.default_tags
+  tags = merge(local.default_tags, local.shared_component_tag)
 }
 
 resource "aws_iam_role" "vpc_flow_logs" {
   name               = "vpc_flow_logs"
   assume_role_policy = data.aws_iam_policy_document.vpc_flow_logs_role_assume_role_policy.json
-  tags               = local.default_tags
+  tags               = merge(local.default_tags, local.shared_component_tag)
 }
 
 data "aws_iam_policy_document" "vpc_flow_logs_role_assume_role_policy" {

--- a/terraform/environment/db_cluster_applications.tf
+++ b/terraform/environment/db_cluster_applications.tf
@@ -21,7 +21,7 @@ resource "aws_rds_cluster" "applications" {
   preferred_backup_window         = "00:14-00:44"
   preferred_maintenance_window    = "wed:22:26-wed:22:56"
   skip_final_snapshot             = local.account.skip_final_snapshot
-  tags                            = local.default_tags
+  tags                            = merge(local.default_tags, local.public_front_component_tag)
   lifecycle {
     ignore_changes = [engine_version]
   }
@@ -40,7 +40,7 @@ resource "aws_db_subnet_group" "applications_rds_cluster" {
   name       = "applications-db-cluster-${local.environment}"
   subnet_ids = data.aws_subnet_ids.private.ids
 
-  tags = local.default_tags
+  tags = merge(local.default_tags, local.public_front_component_tag)
 }
 
 
@@ -49,7 +49,7 @@ resource "aws_security_group" "applications_rds_cluster_client" {
   description            = "client access to applications db cluster"
   vpc_id                 = data.aws_vpc.default.id
   revoke_rules_on_delete = true
-  tags                   = local.default_tags
+  tags                   = merge(local.default_tags, local.public_front_component_tag)
 }
 
 resource "aws_security_group" "applications_rds_cluster" {
@@ -57,7 +57,7 @@ resource "aws_security_group" "applications_rds_cluster" {
   description            = "applications db cluster access"
   vpc_id                 = data.aws_vpc.default.id
   revoke_rules_on_delete = true
-  tags                   = local.default_tags
+  tags                   = merge(local.default_tags, local.public_front_component_tag)
 
   lifecycle {
     create_before_destroy = true

--- a/terraform/environment/db_cluster_applications.tf
+++ b/terraform/environment/db_cluster_applications.tf
@@ -34,6 +34,7 @@ resource "aws_rds_cluster_instance" "applications_cluster_instances" {
   instance_class     = "db.r4.large"
   engine             = aws_rds_cluster.applications.engine
   engine_version     = aws_rds_cluster.applications.engine_version
+  tags               = merge(local.default_tags, local.public_front_component_tag)
 }
 
 resource "aws_db_subnet_group" "applications_rds_cluster" {

--- a/terraform/environment/db_cluster_caseworker.tf
+++ b/terraform/environment/db_cluster_caseworker.tf
@@ -34,6 +34,7 @@ resource "aws_rds_cluster_instance" "caseworker_cluster_instances" {
   instance_class     = "db.r4.large"
   engine             = aws_rds_cluster.caseworker.engine
   engine_version     = aws_rds_cluster.caseworker.engine_version
+  tags               = merge(local.default_tags, local.caseworker_component_tag)
 }
 
 resource "aws_db_subnet_group" "caseworker_rds_cluster" {

--- a/terraform/environment/db_cluster_caseworker.tf
+++ b/terraform/environment/db_cluster_caseworker.tf
@@ -21,7 +21,7 @@ resource "aws_rds_cluster" "caseworker" {
   preferred_backup_window         = "00:14-00:44"
   preferred_maintenance_window    = "wed:22:26-wed:22:56"
   skip_final_snapshot             = local.account.skip_final_snapshot
-  tags                            = local.default_tags
+  tags                            = merge(local.default_tags, local.caseworker_component_tag)
   lifecycle {
     ignore_changes = [engine_version]
   }
@@ -40,7 +40,7 @@ resource "aws_db_subnet_group" "caseworker_rds_cluster" {
   name       = "caseworker-db-cluster-${local.environment}"
   subnet_ids = data.aws_subnet_ids.private.ids
 
-  tags = local.default_tags
+  tags = merge(local.default_tags, local.caseworker_component_tag)
 }
 
 
@@ -49,7 +49,7 @@ resource "aws_security_group" "caseworker_rds_cluster_client" {
   description            = "client access to caseworker db cluster"
   vpc_id                 = data.aws_vpc.default.id
   revoke_rules_on_delete = true
-  tags                   = local.default_tags
+  tags                   = merge(local.default_tags, local.caseworker_component_tag)
 }
 
 resource "aws_security_group" "caseworker_rds_cluster" {
@@ -57,7 +57,7 @@ resource "aws_security_group" "caseworker_rds_cluster" {
   description            = "caseworker db cluster access"
   vpc_id                 = data.aws_vpc.default.id
   revoke_rules_on_delete = true
-  tags                   = local.default_tags
+  tags                   = merge(local.default_tags, local.caseworker_component_tag)
 
   lifecycle {
     create_before_destroy = true

--- a/terraform/environment/dynamodb.tf
+++ b/terraform/environment/dynamodb.tf
@@ -34,5 +34,5 @@ resource "aws_dynamodb_table" "cronlock" {
     type = "S"
   }
 
-  tags = local.default_tags
+  tags = merge(local.default_tags, local.public_front_component_tag)
 }

--- a/terraform/environment/dynamodb.tf
+++ b/terraform/environment/dynamodb.tf
@@ -8,7 +8,7 @@ resource "aws_dynamodb_table" "sessions_public_front" {
     type = "S"
   }
 
-  tags = local.default_tags
+  tags = merge(local.default_tags, local.public_front_component_tag)
 }
 
 resource "aws_dynamodb_table" "sessions_caseworker_front" {
@@ -21,7 +21,7 @@ resource "aws_dynamodb_table" "sessions_caseworker_front" {
     type = "S"
   }
 
-  tags = local.default_tags
+  tags = merge(local.default_tags, local.caseworker_component_tag)
 }
 
 resource "aws_dynamodb_table" "cronlock" {

--- a/terraform/environment/ecs_caseworker_api.tf
+++ b/terraform/environment/ecs_caseworker_api.tf
@@ -20,7 +20,7 @@ resource "aws_ecs_service" "caseworker_api" {
   service_registries {
     registry_arn = aws_service_discovery_service.caseworker_api.arn
   }
-  tags = local.default_tags
+  tags = merge(local.default_tags, local.caseworker_component_tag)
 }
 
 //-----------------------------------------------
@@ -57,7 +57,7 @@ resource "aws_security_group" "caseworker_api_ecs_service" {
   name_prefix = "${local.environment}-caseworker_api-ecs-service"
   description = "caseworker api access"
   vpc_id      = data.aws_vpc.default.id
-  tags        = local.default_tags
+  tags        = merge(local.default_tags, local.caseworker_component_tag)
 }
 
 //----------------------------------
@@ -95,7 +95,7 @@ resource "aws_ecs_task_definition" "caseworker_api" {
   container_definitions    = "[${local.caseworker_api_web}, ${local.caseworker_api_app}]"
   task_role_arn            = aws_iam_role.caseworker_api_task_role.arn
   execution_role_arn       = aws_iam_role.execution_role.arn
-  tags                     = local.default_tags
+  tags                     = merge(local.default_tags, local.caseworker_component_tag)
 }
 
 
@@ -105,7 +105,7 @@ resource "aws_ecs_task_definition" "caseworker_api" {
 resource "aws_iam_role" "caseworker_api_task_role" {
   name               = "${local.environment}-caseworker_api-task-role"
   assume_role_policy = data.aws_iam_policy_document.ecs_assume_policy.json
-  tags               = local.default_tags
+  tags               = merge(local.default_tags, local.caseworker_component_tag)
 }
 
 resource "aws_iam_role_policy_attachment" "caseworker_api_vpc_endpoint_access" {

--- a/terraform/environment/ecs_caseworker_front.tf
+++ b/terraform/environment/ecs_caseworker_front.tf
@@ -23,7 +23,7 @@ resource "aws_ecs_service" "caseworker_front" {
     container_port   = 80
   }
 
-  tags = local.default_tags
+  tags = merge(local.default_tags, local.caseworker_component_tag)
 }
 
 //----------------------------------
@@ -33,7 +33,7 @@ resource "aws_security_group" "caseworker_front_ecs_service" {
   name_prefix = "${local.environment}-caseworker-front-ecs-service"
   description = "caseworker front access"
   vpc_id      = data.aws_vpc.default.id
-  tags        = local.default_tags
+  tags        = merge(local.default_tags, local.caseworker_component_tag)
 }
 
 // 80 in from the ELB
@@ -68,7 +68,7 @@ resource "aws_ecs_task_definition" "caseworker_front" {
   container_definitions    = "[${local.caseworker_front_web}, ${local.caseworker_front_app}]"
   task_role_arn            = aws_iam_role.caseworker_front_task_role.arn
   execution_role_arn       = aws_iam_role.execution_role.arn
-  tags                     = local.default_tags
+  tags                     = merge(local.default_tags, local.caseworker_component_tag)
 }
 
 //----------------
@@ -77,7 +77,7 @@ resource "aws_ecs_task_definition" "caseworker_front" {
 resource "aws_iam_role" "caseworker_front_task_role" {
   name               = "${local.environment}-caseworker-front-task-role"
   assume_role_policy = data.aws_iam_policy_document.ecs_assume_policy.json
-  tags               = local.default_tags
+  tags               = merge(local.default_tags, local.caseworker_component_tag)
 }
 
 resource "aws_iam_role_policy_attachment" "caseworker_front_vpc_endpoint_access" {

--- a/terraform/environment/ecs_cluster.tf
+++ b/terraform/environment/ecs_cluster.tf
@@ -1,6 +1,6 @@
 resource "aws_ecs_cluster" "lpa_refunds" {
   name = "${local.environment}-lpa-refunds"
-  tags = local.default_tags
+  tags = merge(local.default_tags, local.shared_component_tag)
 }
 
 data "aws_cloudwatch_log_group" "lpa_refunds" {
@@ -10,7 +10,7 @@ data "aws_cloudwatch_log_group" "lpa_refunds" {
 resource "aws_iam_role" "execution_role" {
   name               = "${local.environment}-execution-role-ecs-cluster"
   assume_role_policy = data.aws_iam_policy_document.ecs_assume_policy.json
-  tags               = local.default_tags
+  tags               = merge(local.default_tags, local.shared_component_tag)
 }
 
 data "aws_iam_policy_document" "ecs_assume_policy" {
@@ -71,6 +71,3 @@ data "aws_iam_policy_document" "execution_role" {
     resources = ["*"]
   }
 }
-
-
-

--- a/terraform/environment/ecs_ingestion.tf
+++ b/terraform/environment/ecs_ingestion.tf
@@ -19,7 +19,7 @@ resource "aws_ecs_service" "ingestion" {
   }
 
   depends_on = [aws_rds_cluster.applications, aws_rds_cluster.caseworker, aws_iam_role.ingestion_task_role, aws_iam_role.execution_role]
-  tags       = local.default_tags
+  tags       = merge(local.default_tags, local.public_front_component_tag)
 }
 
 //----------------------------------
@@ -29,7 +29,7 @@ resource "aws_security_group" "ingestion_ecs_service" {
   name_prefix = "${local.environment}-ingestion-ecs-service"
   description = "ingestion access"
   vpc_id      = data.aws_vpc.default.id
-  tags        = local.default_tags
+  tags        = merge(local.default_tags, local.public_front_component_tag)
 }
 
 //----------------------------------
@@ -55,7 +55,7 @@ resource "aws_ecs_task_definition" "ingestion" {
   container_definitions    = "[${local.ingestion_app}]"
   task_role_arn            = aws_iam_role.ingestion_task_role.arn
   execution_role_arn       = aws_iam_role.execution_role.arn
-  tags                     = local.default_tags
+  tags                     = merge(local.default_tags, local.public_front_component_tag)
 }
 
 //----------------
@@ -64,7 +64,7 @@ resource "aws_ecs_task_definition" "ingestion" {
 resource "aws_iam_role" "ingestion_task_role" {
   name               = "${local.environment}-ingestion-task-role"
   assume_role_policy = data.aws_iam_policy_document.ecs_assume_policy.json
-  tags               = local.default_tags
+  tags               = merge(local.default_tags, local.public_front_component_tag)
 }
 
 resource "aws_iam_role_policy_attachment" "ingestion_vpc_endpoint_access" {

--- a/terraform/environment/ecs_public_front.tf
+++ b/terraform/environment/ecs_public_front.tf
@@ -28,7 +28,7 @@ resource "aws_ecs_service" "public_front" {
   }
 
   depends_on = [aws_rds_cluster.applications, aws_lb.public_front, aws_iam_role.public_front_task_role, aws_iam_role.execution_role]
-  tags       = local.default_tags
+  tags       = merge(local.default_tags, local.public_front_component_tag)
 }
 
 //----------------------------------
@@ -38,7 +38,7 @@ resource "aws_security_group" "public_front_ecs_service" {
   name_prefix = "${local.environment}-public-front-ecs-service"
   description = "public front ecs access"
   vpc_id      = data.aws_vpc.default.id
-  tags        = local.default_tags
+  tags        = merge(local.default_tags, local.public_front_component_tag)
 }
 
 // 80 in from the ELB
@@ -73,7 +73,7 @@ resource "aws_ecs_task_definition" "public_front" {
   container_definitions    = "[${local.public_front_web}, ${local.public_front_app}]"
   task_role_arn            = aws_iam_role.public_front_task_role.arn
   execution_role_arn       = aws_iam_role.execution_role.arn
-  tags                     = local.default_tags
+  tags                     = merge(local.default_tags, local.public_front_component_tag)
 }
 
 //----------------
@@ -82,7 +82,7 @@ resource "aws_ecs_task_definition" "public_front" {
 resource "aws_iam_role" "public_front_task_role" {
   name               = "${local.environment}-public-front-task-role"
   assume_role_policy = data.aws_iam_policy_document.ecs_assume_policy.json
-  tags               = local.default_tags
+  tags               = merge(local.default_tags, local.public_front_component_tag)
 }
 
 resource "aws_iam_role_policy_attachment" "public_front_vpc_endpoint_access" {

--- a/terraform/environment/ecs_seeding.tf
+++ b/terraform/environment/ecs_seeding.tf
@@ -9,7 +9,7 @@ resource "aws_security_group" "seeding_ecs_service" {
   name_prefix = "${local.environment}-seeding-ecs-service"
   description = "seeding access"
   vpc_id      = data.aws_vpc.default.id
-  tags        = local.default_tags
+  tags        = merge(local.default_tags, local.caseworker_component_tag)
 }
 
 //----------------------------------
@@ -35,7 +35,7 @@ resource "aws_ecs_task_definition" "seeding" {
   container_definitions    = "[${local.seeding_app}]"
   task_role_arn            = aws_iam_role.seeding_task_role.arn
   execution_role_arn       = aws_iam_role.execution_role.arn
-  tags                     = local.default_tags
+  tags                     = merge(local.default_tags, local.caseworker_component_tag)
 }
 
 //----------------
@@ -44,7 +44,7 @@ resource "aws_ecs_task_definition" "seeding" {
 resource "aws_iam_role" "seeding_task_role" {
   name               = "${local.environment}-seeding-task-role"
   assume_role_policy = data.aws_iam_policy_document.ecs_assume_policy.json
-  tags               = local.default_tags
+  tags               = merge(local.default_tags, local.caseworker_component_tag)
 }
 
 resource "aws_iam_role_policy_attachment" "seeding_vpc_endpoint_access" {

--- a/terraform/environment/load_balancer_caseworker_front.tf
+++ b/terraform/environment/load_balancer_caseworker_front.tf
@@ -14,7 +14,7 @@ resource "aws_lb_target_group" "caseworker_front" {
     matcher             = 200
   }
   depends_on = [aws_lb.caseworker_front]
-  tags       = local.default_tags
+  tags       = merge(local.default_tags, local.caseworker_component_tag)
 }
 
 resource "aws_lb" "caseworker_front" {
@@ -22,7 +22,7 @@ resource "aws_lb" "caseworker_front" {
   internal           = false
   load_balancer_type = "application"
   subnets            = data.aws_subnet_ids.public.ids
-  tags               = local.default_tags
+  tags               = merge(local.default_tags, local.caseworker_component_tag)
 
   security_groups = [
     aws_security_group.caseworker_front_loadbalancer.id,
@@ -57,7 +57,7 @@ resource "aws_security_group" "caseworker_front_loadbalancer" {
   name        = "${local.environment}-caseworker-front-loadbalancer"
   description = "caseworker front load balancer access"
   vpc_id      = data.aws_vpc.default.id
-  tags        = local.default_tags
+  tags        = merge(local.default_tags, local.caseworker_component_tag)
 }
 
 resource "aws_security_group_rule" "caseworker_front_loadbalancer_ingress" {

--- a/terraform/environment/load_balancer_caseworker_front.tf
+++ b/terraform/environment/load_balancer_caseworker_front.tf
@@ -46,6 +46,7 @@ resource "aws_lb_listener" "caseworker_front_loadbalancer" {
     target_group_arn = aws_lb_target_group.caseworker_front.arn
     type             = "forward"
   }
+  tags = merge(local.default_tags, local.caseworker_component_tag)
 }
 
 resource "aws_lb_listener_certificate" "caseworker_refunds_opg_digital" {

--- a/terraform/environment/load_balancer_caseworker_front.tf
+++ b/terraform/environment/load_balancer_caseworker_front.tf
@@ -46,7 +46,6 @@ resource "aws_lb_listener" "caseworker_front_loadbalancer" {
     target_group_arn = aws_lb_target_group.caseworker_front.arn
     type             = "forward"
   }
-  tags = merge(local.default_tags, local.caseworker_component_tag)
 }
 
 resource "aws_lb_listener_certificate" "caseworker_refunds_opg_digital" {

--- a/terraform/environment/load_balancer_public_front.tf
+++ b/terraform/environment/load_balancer_public_front.tf
@@ -14,7 +14,7 @@ resource "aws_lb_target_group" "public_front" {
     matcher             = 200
   }
   depends_on = [aws_lb.public_front]
-  tags       = local.default_tags
+  tags       = merge(local.default_tags, local.public_front_component_tag)
 }
 
 resource "aws_lb" "public_front" {
@@ -22,7 +22,7 @@ resource "aws_lb" "public_front" {
   internal           = false
   load_balancer_type = "application"
   subnets            = data.aws_subnet_ids.public.ids
-  tags               = local.default_tags
+  tags               = merge(local.default_tags, local.public_front_component_tag)
 
   security_groups = [
     aws_security_group.public_front_loadbalancer.id,
@@ -101,7 +101,7 @@ resource "aws_security_group" "public_front_loadbalancer" {
   name        = "${local.environment}-public-front-loadbalancer"
   description = "public front load balancer access"
   vpc_id      = data.aws_vpc.default.id
-  tags        = local.default_tags
+  tags        = merge(local.default_tags, local.public_front_component_tag)
 }
 
 resource "aws_security_group_rule" "public_front_loadbalancer_ingress" {

--- a/terraform/environment/locals.tf
+++ b/terraform/environment/locals.tf
@@ -55,5 +55,17 @@ locals {
     source-code            = "https://github.com/ministryofjustice/opg-refunds"
   }
 
+  public_component_tag = {
+    component             = "public-front"
+  }
+
+  caseworker_component_tag = {
+    component             = "caseworker"
+  }
+
+  shared_component_tag = {
+    component             = "shared"
+  }
+
   default_tags = merge(local.mandatory_moj_tags, local.optional_tags)
 }

--- a/terraform/environment/locals.tf
+++ b/terraform/environment/locals.tf
@@ -55,7 +55,7 @@ locals {
     source-code            = "https://github.com/ministryofjustice/opg-refunds"
   }
 
-  public_component_tag = {
+  public_front_component_tag = {
     component = "public-front"
   }
 

--- a/terraform/environment/locals.tf
+++ b/terraform/environment/locals.tf
@@ -56,15 +56,15 @@ locals {
   }
 
   public_component_tag = {
-    component             = "public-front"
+    component = "public-front"
   }
 
   caseworker_component_tag = {
-    component             = "caseworker"
+    component = "caseworker"
   }
 
   shared_component_tag = {
-    component             = "shared"
+    component = "shared"
   }
 
   default_tags = merge(local.mandatory_moj_tags, local.optional_tags)


### PR DESCRIPTION
## Purpose
_add public-front, caseworker and shared as possible tags to AWS resources. The initial purpose of this is to allow us to get costings for the refunds service_

## Approach

_Updates to terraform tf files to add tags appropriately to all taggable resources. To test that this is done properly , I have verified through the AWS console that examples of all 3 of these tags can be seen_

## Learning

_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about the Refunds service_

## Checklist

* [x] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] The product team have tested these changes
