### PR TITLE
Lpa 3731 secrets change

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,39 @@
+SHELL := '/bin/bash'
+NOTIFY := $(shell aws-vault exec moj-refunds-dev -- aws secretsmanager get-secret-value --secret-id development/opg_refunds_notify_api_key | jq -r .'SecretString')
+
+.PHONY: all
+all:
+	@${MAKE} dc-up
+
+.PHONY: dc-run
+dc-run:
+	@export OPG_REFUNDS_NOTIFY_API_KEY=${NOTIFY}; \
+	docker-compose run public-composer
+
+	@export OPG_REFUNDS_NOTIFY_API_KEY=${NOTIFY}; \
+	docker-compose run caseworker-front-composer
+
+	@export OPG_REFUNDS_NOTIFY_API_KEY=${NOTIFY}; \
+	docker-compose run caseworker-api-composer
+
+
+.PHONY: dc-up
+dc-up:
+	@export OPG_REFUNDS_NOTIFY_API_KEY=${NOTIFY}; \
+	docker-compose up
+
+.PHONY: dc-build
+dc-build:
+	@export OPG_REFUNDS_NOTIFY_API_KEY=${NOTIFY}; \
+	docker-compose build
+
+
+.PHONY: dc-build-clean
+dc-build-clean:
+	@export OPG_REFUNDS_NOTIFY_API_KEY=${NOTIFY}; \
+	docker-compose build --no-cache
+
+.PHONY: dc-down
+dc-down:
+	@export OPG_REFUNDS_NOTIFY_API_KEY=${NOTIFY}; \
+	docker-compose down

--- a/README.md
+++ b/README.md
@@ -4,21 +4,21 @@ The Office of the Public Guardian LPA Refunds service: Managed by opg-org-infra 
 
 ## Local Development Setup
 
-The first time you bring up the environment:
+Intially, download the repo via:
 
 ```
 git clone git@github.com:ministryofjustice/opg-refunds.git
 cd opg-refunds
-
-docker-compose run public-composer
-docker-compose run caseworker-front-composer
-docker-compose run caseworker-api-composer
-
-docker-compose up
 ```
 
-You will also need a copy of the local config file `public-front/config/autoload/local.php`. Any developer on the team
-should be able to provide you with this.
+Within `opg-refunds` directory to *run* the project for the first time use the following:
+
+```
+make dc-run
+make
+```
+
+The `Makefile` will fetch secrets using `aws secretsmanager` and `docker-compose` commands together to pass along environment variables removing the need for local configuration files.
 
 
 The Public service will be available via https://localhost:9001/start
@@ -26,9 +26,9 @@ The Caseworker service will be available via https://localhost:9002
 
 The Caseworker API service will be available (direct) via http://localhost:9003
 
-After the first time, you bring up the environment with:
+After the first time, you can *run* the project by:
 ```
-docker-compose up
+make
 ```
 
 ### Updating composer dependencies

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -106,7 +106,8 @@ services:
       #ENABLE_XDEBUG: 'true'
       PHP_IDE_CONFIG: serverName=public-front-app
       XDEBUG_CONFIG: remote_host=host.docker.internal remote_enable=1
-
+      # from shell vars
+      OPG_REFUNDS_NOTIFY_API_KEY: "${OPG_REFUNDS_NOTIFY_API_KEY}"
   public-composer:
     image: composer
     volumes:
@@ -184,7 +185,8 @@ services:
       #ENABLE_XDEBUG: 'true'
       PHP_IDE_CONFIG: serverName=caseworker-front-app
       XDEBUG_CONFIG: remote_host=host.docker.internal remote_enable=1
-
+      # from shell vars
+      OPG_REFUNDS_NOTIFY_API_KEY: "${OPG_REFUNDS_NOTIFY_API_KEY}"
   caseworker-front-composer:
     image: composer
     volumes:
@@ -278,7 +280,8 @@ services:
       #ENABLE_XDEBUG: 'true'
       PHP_IDE_CONFIG: serverName=caseworker-api-app
       XDEBUG_CONFIG: remote_host=host.docker.internal remote_enable=1
-
+      # from shell vars
+      OPG_REFUNDS_NOTIFY_API_KEY: "${OPG_REFUNDS_NOTIFY_API_KEY}"
   caseworker-api-composer:
     image: caseworker-api-composer
     build:
@@ -331,7 +334,8 @@ services:
       ENABLE_XDEBUG: 'true'
       PHP_IDE_CONFIG: serverName=caseworker-api-ingestion
       XDEBUG_CONFIG: remote_host=host.docker.internal remote_enable=1
-
+      # from shell vars
+      OPG_REFUNDS_NOTIFY_API_KEY: "${OPG_REFUNDS_NOTIFY_API_KEY}"
   caseworker-api-seeding:
     container_name: caseworker-api-seeding
     image: caseworker-api-seeding


### PR DESCRIPTION
## Purpose
Remove the need for local php file containing secret keys

Fixes LPA-3731

## Approach

Using the dev environment secrets via aws secret manager within a Makefile and bundle some common tasks in there

## Checklist

* [x] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] The product team have tested these changes
