### PR TITLE
LPAL-287 reduce sizing of ecs tasks to be minimum.

### DIFF
--- a/terraform/environment/ecs_caseworker_api.tf
+++ b/terraform/environment/ecs_caseworker_api.tf
@@ -91,8 +91,8 @@ resource "aws_ecs_task_definition" "caseworker_api" {
   family                   = "${local.environment}-caseworker_api"
   requires_compatibilities = ["FARGATE"]
   network_mode             = "awsvpc"
-  cpu                      = 2048
-  memory                   = 4096
+  cpu                      = 256
+  memory                   = 512
   container_definitions    = "[${local.caseworker_api_web}, ${local.caseworker_api_app}]"
   task_role_arn            = aws_iam_role.caseworker_api_task_role.arn
   execution_role_arn       = aws_iam_role.execution_role.arn

--- a/terraform/environment/ecs_caseworker_front.tf
+++ b/terraform/environment/ecs_caseworker_front.tf
@@ -64,8 +64,8 @@ resource "aws_ecs_task_definition" "caseworker_front" {
   family                   = "${local.environment}-caseworker-front"
   requires_compatibilities = ["FARGATE"]
   network_mode             = "awsvpc"
-  cpu                      = 2048
-  memory                   = 4096
+  cpu                      = 256
+  memory                   = 512
   container_definitions    = "[${local.caseworker_front_web}, ${local.caseworker_front_app}]"
   task_role_arn            = aws_iam_role.caseworker_front_task_role.arn
   execution_role_arn       = aws_iam_role.execution_role.arn

--- a/terraform/environment/ecs_ingestion.tf
+++ b/terraform/environment/ecs_ingestion.tf
@@ -51,8 +51,8 @@ resource "aws_ecs_task_definition" "ingestion" {
   family                   = "${local.environment}-ingestion"
   requires_compatibilities = ["FARGATE"]
   network_mode             = "awsvpc"
-  cpu                      = 2048
-  memory                   = 4096
+  cpu                      = 256
+  memory                   = 512
   container_definitions    = "[${local.ingestion_app}]"
   task_role_arn            = aws_iam_role.ingestion_task_role.arn
   execution_role_arn       = aws_iam_role.execution_role.arn

--- a/terraform/environment/ecs_seeding.tf
+++ b/terraform/environment/ecs_seeding.tf
@@ -30,8 +30,8 @@ resource "aws_ecs_task_definition" "seeding" {
   family                   = "${local.environment}-seeding"
   requires_compatibilities = ["FARGATE"]
   network_mode             = "awsvpc"
-  cpu                      = 2048
-  memory                   = 4096
+  cpu                      = 256
+  memory                   = 512
   container_definitions    = "[${local.seeding_app}]"
   task_role_arn            = aws_iam_role.seeding_task_role.arn
   execution_role_arn       = aws_iam_role.execution_role.arn


### PR DESCRIPTION
## Purpose
To reduce ECS tasks to minimum sizing for instances (FARGATE Based)

work for LPAL-287

## Approach
Based on calculations of usage over a period of time, we are reducing sizes of all ECS tasks to minimum where this is not done already. this has been done post public facing access switch off.

- See spreadsheet (MOJ access only): https://docs.google.com/spreadsheets/d/17LewX0ChHEOTkeoHj6db4Jalaz7P2cuNPQlgR5_bjNU/edit?usp=sharing

## Learning

- https://aws.amazon.com/fargate/pricing/ 
- https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-cpu-memory-error.html


## Checklist

* [X] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] The product team have tested these changes
