### PR TITLE
add forced dependancies for autoscales

### DIFF
--- a/terraform/environment/ecs_hibernation.tf
+++ b/terraform/environment/ecs_hibernation.tf
@@ -22,5 +22,11 @@ module "daytime" {
       scale_up_to   = local.account.public_front_autoscaling_maximum
     }
   }
+  depends_on = [
+    aws_appautoscaling_target.public_front,
+    aws_appautoscaling_policy.cpu_track_metric,
+    aws_appautoscaling_policy.memory_track_metric,
+    aws_cloudwatch_metric_alarm.public_front_max_scaling
+  ]
 }
 

--- a/terraform/environment/locals.tf
+++ b/terraform/environment/locals.tf
@@ -1,6 +1,6 @@
 # variables for terraform.tfvars.json
 variable "account_mapping" {
-  type = map
+  type = map(any)
 }
 
 variable "container_version" {


### PR DESCRIPTION
## Purpose
to fix concurrency exception in refunds terraform when creating / modifying ECS autoscale setup.

Relates to LPAL-313

## Approach

add `depends_on` to hibernation autoscale.

## Learning

see https://github.com/ministryofjustice/opg-lpa/pull/395

## Checklist

* [X] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] The product team have tested these changes
