### PR TITLE
correct to match UTC time

### DIFF
--- a/terraform/environment/terraform.tfvars.json
+++ b/terraform/environment/terraform.tfvars.json
@@ -24,8 +24,8 @@
       "days_to_wait_before_expiry": 1,
       "opg_refunds_google_analytics_tracking_id": "",
       "opg_refunds_google_analytics_tracking_gov_id": "",
-      "scale_up_schedule" : "cron(00 08 ? * MON-FRI *)",
-      "scale_down_schedule" : "cron(00 19 ? * MON-FRI *)"
+      "scale_up_schedule" : "cron(00 07 ? * MON-FRI *)",
+      "scale_down_schedule" : "cron(00 18 ? * MON-FRI *)"
     },
     "preproduction": {
       "account_id": "764856231715",
@@ -46,8 +46,8 @@
       "days_to_wait_before_expiry": 1,
       "opg_refunds_google_analytics_tracking_id": "",
       "opg_refunds_google_analytics_tracking_gov_id": "",
-      "scale_up_schedule" : "cron(00 08 ? * MON-FRI *)",
-      "scale_down_schedule" : "cron(00 19 ? * MON-FRI *)"
+      "scale_up_schedule" : "cron(00 07 ? * MON-FRI *)",
+      "scale_down_schedule" : "cron(00 18 ? * MON-FRI *)"
     },
     "production": {
       "account_id": "805626386523",
@@ -68,8 +68,8 @@
       "days_to_wait_before_expiry": 30,
       "opg_refunds_google_analytics_tracking_id": "UA-105655306-1",
       "opg_refunds_google_analytics_tracking_gov_id": "UA-145652997-1",
-      "scale_up_schedule" : "cron(30 05 ? * MON-SAT *)",
-      "scale_down_schedule" : "cron(30 22 ? * MON-SAT *)"
+      "scale_up_schedule" : "cron(30 04 ? * MON-SAT *)",
+      "scale_down_schedule" : "cron(30 21 ? * MON-SAT *)"
 
     }
   }


### PR DESCRIPTION
## Purpose

cron does not adjust ofr daylight saving.
This ticket adjusts so that our up and down schedules work on the time that BST is set now.


Fixes LPAL-344

## Approach

- update `tfvars.json` on `scale_up_schedule` and `scale_down_schedule`

## Learning

## Checklist

* [X] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] The product team have tested these changes
