### PR TITLE
pin PHP to 7.4.16 - will upgrade when fix available.

### DIFF
--- a/caseworker-api/docker/app/Dockerfile
+++ b/caseworker-api/docker/app/Dockerfile
@@ -4,7 +4,7 @@ COPY caseworker-api /app
 
 RUN composer install --prefer-dist --no-suggest --no-interaction --no-scripts --optimize-autoloader
 
-FROM php:7-fpm-alpine
+FROM php:7.4.16-fpm-alpine
 
 # Postgres lib needs to remain in the container
 RUN apk add --update --no-cache postgresql-libs libpng libzip

--- a/caseworker-api/docker/ingestion/Dockerfile
+++ b/caseworker-api/docker/ingestion/Dockerfile
@@ -4,7 +4,7 @@ COPY caseworker-api /app
 
 RUN composer install --prefer-dist --no-suggest --no-interaction --no-scripts --optimize-autoloader
 
-FROM php:7-cli-alpine
+FROM php:7.4.16-cli-alpine
 
 # Postgres needs to remain in the container
 RUN apk add --update --no-cache postgresql-libs postgresql-client

--- a/caseworker-api/docker/seeding/Dockerfile
+++ b/caseworker-api/docker/seeding/Dockerfile
@@ -4,7 +4,7 @@ COPY caseworker-api/docker/seeding /app
 
 # RUN composer install --prefer-dist --no-suggest --no-interaction --no-scripts --optimize-autoloader
 
-FROM php:7-cli-alpine
+FROM php:7.4.16-cli-alpine
 
 # Postgres needs to remain in the container
 RUN apk add --update --no-cache postgresql-libs postgresql-client

--- a/caseworker-front/docker/app/Dockerfile
+++ b/caseworker-front/docker/app/Dockerfile
@@ -4,7 +4,7 @@ COPY caseworker-front /app
 
 RUN composer install --prefer-dist --no-suggest --no-interaction --no-scripts --optimize-autoloader
 
-FROM php:7-fpm-alpine
+FROM php:7.4.16-fpm-alpine
 
 RUN apk add --update --no-cache --virtual .build-dependencies $PHPIZE_DEPS \
         && pecl install xdebug \

--- a/public-front/docker/app/Dockerfile
+++ b/public-front/docker/app/Dockerfile
@@ -4,7 +4,7 @@ COPY public-front /app
 
 RUN composer install --prefer-dist --no-suggest --no-interaction --no-scripts --optimize-autoloader
 
-FROM php:7-fpm-alpine
+FROM php:7.4.16-fpm-alpine
 
 RUN apk add --update --no-cache postgresql-libs
 


### PR DESCRIPTION
## Purpose

fix PHP docker versions to 7.4.16, due to issues with later release of PHP 7.4 that has issues with doctrine.

## Approach

pin dockerfiles.

## Learning

see  https://bugs.php.net/bug.php?id=81002 

## Checklist

* [X] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] The product team have tested these changes
