### PR TITLE
Lpal 398 archive caseworkers db - setup infra

### DIFF
--- a/terraform/account/archive.tf
+++ b/terraform/account/archive.tf
@@ -51,3 +51,54 @@ resource "aws_s3_bucket_policy" "refunds_archive_policy" {
 
 
 
+# set up RDS to S3 export roles
+# see https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_ExportSnapshot.html#USER_ExportSnapshot.SetupIAMRole
+resource "aws_iam_role" "refunds_caseworker_export_role" {
+  name               = "refunds-caseworker-export-role"
+  assume_role_policy = data.aws_iam_policy_document.refunds_caseworker_export_assume_role_policy
+  tags               = merge(local.default_tags)
+}
+
+# Assume role policy for export role
+data "aws_iam_policy_document" "refunds_caseworker_export_assume_role_policy" {
+  statement {
+    actions = ["sts:AssumeRole"]
+    effect  = "Allow"
+    principals {
+      type        = "Service"
+      identifiers = ["export.rds.amazonaws.com"]
+    }
+  }
+}
+
+# set up IAM policy for export
+resource "aws_iam_policy" "refunds_caseworker_export_policy" {
+  name        = "refunds-caseworker-export-policy"
+  description = "this policy allows export of RDS snapshots to an S3 bucket"
+  policy      = data.aws_iam_policy_document.refunds_caseworker_export_policy
+}
+
+#policy document setting out access for export role
+data "aws_iam_policy_document" "refunds_caseworker_export_policy" {
+  statement {
+    sid    = "ExportPolicy"
+    effect = "Allow"
+    actions = [
+      "s3:PutObject*",
+      "s3:ListBucket",
+      "s3:GetObject*",
+      "s3:DeleteObject*",
+      "s3:GetBucketLocation"
+    ]
+    resources = [
+      "arn:aws:s3:::${aws_s3_bucket.refunds_archive.arn}",
+      "arn:aws:s3:::${aws_s3_bucket.refunds_archive.arn}/*"
+    ]
+  }
+}
+
+# create a policy attachment for the export role.
+resource "aws_iam_role_policy_attachment" "refunds_caseworker_export_role_policy_attachment" {
+  role       = aws_iam_role.refunds_caseworker_export_role
+  policy_arn = aws_iam_policy.refunds_caseworker_export_policy
+}

--- a/terraform/account/archive.tf
+++ b/terraform/account/archive.tf
@@ -144,7 +144,8 @@ data "aws_iam_policy_document" "kms_refunds_caseworker_db_archive_key" {
     principals {
       type = "AWS"
       identifiers = [
-        "arn:aws:iam::${local.account.account_id}:root"
+        "arn:aws:iam::${local.account.account_id}:root",
+        "arn:aws:iam::${local.account.account_id}:role/breakglass",
       ]
     }
     resources = ["*"]

--- a/terraform/account/archive.tf
+++ b/terraform/account/archive.tf
@@ -5,7 +5,7 @@ resource "aws_kms_key" "kms_refunds_s3_archive_key" {
 }
 
 resource "aws_kms_alias" "kms_refunds_s3_archive_key_alias" {
-  name          = "alias/${terraform.workspace}-archive-s3-server-side-encryption-key"
+  name          = "alias/lpa-refunds-${terraform.workspace}-archive-s3-server-side-encryption-key"
   target_key_id = aws_kms_key.kms_refunds_s3_archive_key.key_id
 }
 
@@ -141,7 +141,7 @@ resource "aws_kms_key" "refunds_caseworker_db_archive_key" {
 }
 
 resource "aws_kms_alias" "refunds_casewoker_db_archive_key_alias" {
-  name          = "alias/${terraform.workspace}-archive-caseworker-db-encryption-key"
+  name          = "alias/lpa-refunds-${terraform.workspace}-archive-caseworker-db-encryption-key"
   target_key_id = aws_kms_key.refunds_caseworker_db_archive_key.key_id
 }
 

--- a/terraform/account/archive.tf
+++ b/terraform/account/archive.tf
@@ -5,7 +5,7 @@ resource "aws_kms_key" "kms_refunds_s3_archive_key" {
 }
 
 resource "aws_kms_alias" "kms_refunds_s3_archive_key_alias" {
-  name          = "alias/s3_archive_server_side_encryption_key"
+  name          = "alias/${terraform.workspace}-archive-s3-server-side-encryption-key"
   target_key_id = aws_kms_key.kms_refunds_s3_archive_key.key_id
 }
 
@@ -141,7 +141,7 @@ resource "aws_kms_key" "refunds_caseworker_db_archive_key" {
 }
 
 resource "aws_kms_alias" "refunds_casewoker_db_archive_key_alias" {
-  name          = "alias/archive_caseworker_db_key"
+  name          = "alias/${terraform.workspace}-archive-caseworker-db-encryption-key"
   target_key_id = aws_kms_key.refunds_caseworker_db_archive_key.key_id
 }
 

--- a/terraform/account/archive.tf
+++ b/terraform/account/archive.tf
@@ -1,0 +1,53 @@
+# allow public read on the bucket and objects,
+# but access will be limited by policy to moj_sites
+resource "aws_s3_bucket" "refunds_archive" {
+  bucket = "refunds-${terraform.workspace}-caseworker-archive"
+  acl    = "private"
+  tags   = merge(local.default_tags)
+
+}
+
+# policy that allows breakglass users to put objects
+# into the bucket
+data "aws_iam_policy_document" "refunds_archive_policy_document" {
+  statement {
+    sid     = "allowUploadFromSpecificARNs"
+    effect  = "Allow"
+    actions = ["s3:PutObject"]
+
+    principals {
+      identifiers = ["arn:aws:iam::${local.account.account_id}:role/breakglass"]
+      type        = "AWS"
+    }
+    resources = [aws_s3_bucket.refunds_archive.arn, "${aws_s3_bucket.refunds_archive.arn}/*"]
+  }
+  # ssl requests only
+  statement {
+    sid     = "DenyNoneSSLRequests"
+    effect  = "Deny"
+    actions = ["s3:*"]
+    resources = [
+      aws_s3_bucket.refunds_archive.arn,
+      "${aws_s3_bucket.refunds_archive.arn}/*"
+    ]
+    condition {
+      test     = "Bool"
+      variable = "aws:SecureTransport"
+      values   = [false]
+    }
+
+    principals {
+      type        = "AWS"
+      identifiers = ["*"]
+    }
+  }
+}
+
+resource "aws_s3_bucket_policy" "refunds_archive_policy" {
+  depends_on = [aws_s3_bucket.refunds_archive]
+  bucket     = aws_s3_bucket.refunds_archive.id
+  policy     = data.aws_iam_policy_document.refunds_archive_policy_document.json
+}
+
+
+

--- a/terraform/account/archive.tf
+++ b/terraform/account/archive.tf
@@ -1,5 +1,5 @@
 #KMS key for Server Side Encryption (SSE) of S3 buckets
-resource "aws_kms_key" "kms_refunds_s3_archive_key"{
+resource "aws_kms_key" "kms_refunds_s3_archive_key" {
   description             = "This key is used to encrypt S3 bucket objects"
   deletion_window_in_days = 10
 }
@@ -18,7 +18,17 @@ resource "aws_s3_bucket" "refunds_archive" {
     }
   }
 
-  tags   = merge(local.default_tags)
+  #all objects immediately subject to Intelligent Tiering allowing for automated use of storage tiers.
+  lifecycle_rule {
+    id      = "archive"
+    enabled = true
+    transition {
+      days          = 0
+      storage_class = "INTELLIGENT_TIERING"
+    }
+  }
+
+  tags = merge(local.default_tags)
 
 }
 

--- a/terraform/account/archive.tf
+++ b/terraform/account/archive.tf
@@ -138,12 +138,13 @@ resource "aws_kms_key" "refunds_caseworker_db_archive_key" {
 #allow only breakglass role to run this - we do not need op access.
 data "aws_iam_policy_document" "kms_refunds_caseworker_db_archive_key" {
   statement {
+
     sid    = "KMS admin"
     effect = "Allow"
     principals {
       type = "AWS"
       identifiers = [
-        "arn:aws:iam::${local.account.account_id}:role/breakglass"
+        "arn:aws:iam::${local.account.account_id}:root"
       ]
     }
     resources = ["*"]

--- a/terraform/account/archive.tf
+++ b/terraform/account/archive.tf
@@ -1,8 +1,23 @@
-# allow public read on the bucket and objects,
-# but access will be limited by policy to moj_sites
+#KMS key for Server Side Encryption (SSE) of S3 buckets
+resource "aws_kms_key" "kms_refunds_s3_archive_key"{
+  description             = "This key is used to encrypt S3 bucket objects"
+  deletion_window_in_days = 10
+}
+
+#archive bucket - enable SSE by default
 resource "aws_s3_bucket" "refunds_archive" {
   bucket = "refunds-${terraform.workspace}-caseworker-archive"
   acl    = "private"
+
+  server_side_encryption_configuration {
+    rule {
+      apply_server_side_encryption_by_default {
+        kms_master_key_id = aws_kms_key.kms_refunds_s3_archive_key.arn
+        sse_algorithm     = "aws:kms"
+      }
+    }
+  }
+
   tags   = merge(local.default_tags)
 
 }
@@ -55,7 +70,7 @@ resource "aws_s3_bucket_policy" "refunds_archive_policy" {
 # see https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_ExportSnapshot.html#USER_ExportSnapshot.SetupIAMRole
 resource "aws_iam_role" "refunds_caseworker_export_role" {
   name               = "refunds-caseworker-export-role"
-  assume_role_policy = data.aws_iam_policy_document.refunds_caseworker_export_assume_role_policy
+  assume_role_policy = data.aws_iam_policy_document.refunds_caseworker_export_assume_role_policy.json
   tags               = merge(local.default_tags)
 }
 
@@ -75,7 +90,7 @@ data "aws_iam_policy_document" "refunds_caseworker_export_assume_role_policy" {
 resource "aws_iam_policy" "refunds_caseworker_export_policy" {
   name        = "refunds-caseworker-export-policy"
   description = "this policy allows export of RDS snapshots to an S3 bucket"
-  policy      = data.aws_iam_policy_document.refunds_caseworker_export_policy
+  policy      = data.aws_iam_policy_document.refunds_caseworker_export_policy.json
 }
 
 #policy document setting out access for export role
@@ -99,6 +114,46 @@ data "aws_iam_policy_document" "refunds_caseworker_export_policy" {
 
 # create a policy attachment for the export role.
 resource "aws_iam_role_policy_attachment" "refunds_caseworker_export_role_policy_attachment" {
-  role       = aws_iam_role.refunds_caseworker_export_role
-  policy_arn = aws_iam_policy.refunds_caseworker_export_policy
+  role       = aws_iam_role.refunds_caseworker_export_role.name
+  policy_arn = aws_iam_policy.refunds_caseworker_export_policy.arn
+}
+
+# Add aws CMK for encrypting the data.
+resource "aws_kms_key" "refunds_caseworker_db_archive_key" {
+  description             = "Refunds caseworker archive key"
+  deletion_window_in_days = 10
+  policy                  = data.aws_iam_policy_document.kms_refunds_caseworker_db_archive_key.json
+}
+
+#allow only breakglass role to run this - we do not need op access.
+data "aws_iam_policy_document" "kms_refunds_caseworker_db_archive_key" {
+  statement {
+    sid    = "KMS admin"
+    effect = "Allow"
+    principals {
+      type = "AWS"
+      identifiers = [
+        "arn:aws:iam::${local.account.account_id}:role/breakglass"
+      ]
+    }
+    resources = ["*"]
+    actions = [
+      "kms:Encrypt",
+      "kms:Decrypt",
+      "kms:ReEncrypt",
+      "kms:GenerateDataKey*",
+      "kms:Create*",
+      "kms:Describe*",
+      "kms:Enable*",
+      "kms:List*",
+      "kms:Put*",
+      "kms:Update*",
+      "kms:Revoke*",
+      "kms:Disable*",
+      "kms:Get*",
+      "kms:Delete*",
+      "kms:ScheduleKeyDeletion",
+      "kms:CancelKeyDeletion"
+    ]
+  }
 }

--- a/terraform/account/archive.tf
+++ b/terraform/account/archive.tf
@@ -4,6 +4,11 @@ resource "aws_kms_key" "kms_refunds_s3_archive_key" {
   deletion_window_in_days = 10
 }
 
+resource "aws_kms_alias" "kms_refunds_s3_archive_key_alias" {
+  name          = "alias/s3_archive_server_side_encryption_key"
+  target_key_id = aws_kms_key.kms_refunds_s3_archive_key.key_id
+}
+
 #archive bucket - enable SSE by default
 resource "aws_s3_bucket" "refunds_archive" {
   bucket = "refunds-${terraform.workspace}-caseworker-archive"
@@ -133,6 +138,11 @@ resource "aws_kms_key" "refunds_caseworker_db_archive_key" {
   description             = "Refunds caseworker archive key"
   deletion_window_in_days = 10
   policy                  = data.aws_iam_policy_document.kms_refunds_caseworker_db_archive_key.json
+}
+
+resource "aws_kms_alias" "refunds_casewoker_db_archive_key_alias" {
+  name          = "alias/archive_caseworker_db_key"
+  target_key_id = aws_kms_key.refunds_caseworker_db_archive_key.key_id
 }
 
 #allow only breakglass role to run this - we do not need op access.

--- a/terraform/account/lb_access_logs.tf
+++ b/terraform/account/lb_access_logs.tf
@@ -7,7 +7,7 @@ data "aws_iam_policy_document" "loadbalancer_logging" {
     sid = "accessLogBucketAccess"
 
     resources = [
-      "${aws_s3_bucket.access_log.arn}",
+      aws_s3_bucket.access_log.arn,
       "${aws_s3_bucket.access_log.arn}/*",
     ]
 


### PR DESCRIPTION
## Purpose
- To support the export of a snapshot of the caseworker database to S3, in order to archive it.
- Attempt to use intelligent Tiering for the bucket so that archival object will go through the storage tiers automatically.

**Note:** There is no need to archive the applications db as its data is highly transient in nature.

Fixes LPAL-398

## Approach

- Follow guide on how to export a [RDS snapshot to S3](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_ExportSnapshot.html)
- Use intelligent tiering in the bucket

## Learning

- Exporting RDS snapshot to S3: https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_ExportSnapshot.html
   - The above being a good jump off point for a number of articles including some listed below.
- Providing access to an Amazon S3 bucket using an IAM role:https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_ExportSnapshot.html#USER_ExportSnapshot.SetupIAMRole
 - AWS Json Policy elements: Prinicipal: https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_principal.html
 - S3 Default bucket encryption: https://docs.aws.amazon.com/AmazonS3/latest/userguide/default-bucket-encryption.html
- Encrypting Amazon RDS Resources: https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Overview.Encryption.html
- S3 Storage classes: https://aws.amazon.com/s3/storage-classes/

## Checklist

* [X] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] The product team have tested these changes
