### PR TITLE
LPAL-398: export archive - FIX: remove ARN prefix as not needed in terraform

### DIFF
--- a/terraform/account/archive.tf
+++ b/terraform/account/archive.tf
@@ -121,8 +121,8 @@ data "aws_iam_policy_document" "refunds_caseworker_export_policy" {
       "s3:GetBucketLocation"
     ]
     resources = [
-      "arn:aws:s3:::${aws_s3_bucket.refunds_archive.arn}",
-      "arn:aws:s3:::${aws_s3_bucket.refunds_archive.arn}/*"
+      ${aws_s3_bucket.refunds_archive.arn},
+      "${aws_s3_bucket.refunds_archive.arn}/*"
     ]
   }
 }

--- a/terraform/account/archive.tf
+++ b/terraform/account/archive.tf
@@ -121,7 +121,7 @@ data "aws_iam_policy_document" "refunds_caseworker_export_policy" {
       "s3:GetBucketLocation"
     ]
     resources = [
-      ${aws_s3_bucket.refunds_archive.arn},
+      aws_s3_bucket.refunds_archive.arn,
       "${aws_s3_bucket.refunds_archive.arn}/*"
     ]
   }

--- a/terraform/account/locals.tf
+++ b/terraform/account/locals.tf
@@ -1,6 +1,6 @@
 # variables for terraform.tfvars.json
 variable "account_mapping" {
-  type = map
+  type = map(any)
 }
 
 variable "accounts" {


### PR DESCRIPTION
## Purpose

to fix export policy document to remove extraneous prefix.

Fixes LPAL-398

## Approach

remove `arn:aws:s3:::` as this already gets applied by the reference.

## Learning

_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about the Refunds service_

## Checklist

* [x] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] The product team have tested these changes
